### PR TITLE
GCW-1780 Add expire command when setting keys

### DIFF
--- a/app.js
+++ b/app.js
@@ -101,7 +101,7 @@ app.post("/send", function (req, res) {
         return;
       }
 
-      var dataId = store.add(nsp.name, device.storeListName, req.body.event, args);
+      var dataId = store.add(nsp.name, device.storeListName, req.body.event, args, config.device_ttl);
       logger.info({"category":"message stored","site":nsp.name,"requestId":reqId,"dataId": dataId, "room": room, "deviceId": device.id});
 
       var socket = nsp.getSocket(device.socketId);

--- a/store.js
+++ b/store.js
@@ -27,10 +27,11 @@ module.exports = function(redisConfig) {
   }
 
   return {
-    add: function(siteName, listName, event, data) {
+    add: function(siteName, listName, event, data, ttl) {
       var dataId = genId();
       var redisKey = keyName(siteName, listName, event);
       redisClient.rpush(redisKey, dataId + ":" + JSON.stringify(data));
+      redisClient.expire(redisKey, ttl);
       return dataId;
     },
 


### PR DESCRIPTION
When we store data in Redis, we want to set the keys to expire. Here we are setting keys via `RPUSH` so we need to send a separate `EXPIRE` command. We've chosen the device_ttl (default 1 hour) as the key expiry.